### PR TITLE
Add Caddy 2 example for the server versions.

### DIFF
--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,27 @@
+#---
+# FeatherWiki example Caddyfile for Caddy 2
+#---
+# This configuration expects FeatherWiki to be named 'index.html'
+# As the webdav directive is not built-in, select it when
+# downloading your caddy binary, or use
+# 'xcaddy --with github.com/mholt/caddy-webdav'
+#---
+# change this to the domain where FeatherWiki is uploaded
+# NOTE: Since saving is protected via basicauth, ensure
+#  HTTPS is used when accessing your wiki
+# if 'http://' isn't specified, Caddy redirects to HTTPS by default.
+wiki.example.com {
+	@notget not method GET
+	@notoptget not method OPTIONS or not method GET
+
+	route @notget {
+		# The default user and pass is test. You can generate your own
+		# password via 'caddy hash-password'
+		basicauth @notoptget {
+			test $2a$14$OEW51Xqqmg6p5pu0sQmz2eS7oRPr7hCRGHt0hWYFXJu0vrofxXOby
+		}
+		webdav
+	}
+	rewrite @notoptget /index.html
+	file_server browse
+}


### PR DESCRIPTION
First of all, I'm sorry for not creating a PR via the Codeberg repository. I am unfortunately unable to solve their captcha.

This adds a Caddy 2 example. Besides serving the FeatherWiki file, it exposes the FeatherWiki domain through webDav, so that saving is possible. Nothing else should be necessary to host a wiki instance.

Any method other than *GET* and *OPTIONS* is password-protected via basic auth.

The file is commented so that people unfamiliar with Caddy can change the necessary things, e.g. domain or password.