### PR TITLE
ARIA Improvements for screen reader users

### DIFF
--- a/helpers/pell.js
+++ b/helpers/pell.js
@@ -118,6 +118,7 @@ export const init = settings => {
 
   const actionbar = ce('div')
   actionbar.className = classes.actionbar
+  actionbar.role = 'toolbar'
   ac(settings.element, actionbar)
 
   const content = settings.element.content = ce('div')

--- a/views/global.js
+++ b/views/global.js
@@ -108,7 +108,7 @@ export const globalView = (state, emit) => {
     </footer>
     <div class=notis>
       ${notis.map(n => html`<div class=noti style="${n.css}" onclick=${() => emit(events.REMOVE_NOTI, n.id)} title="Click to close">
-        ${n.text}<span class=fr>×</span>
+        <span role=alert>${n.text}</span><span class=fr>×</span>
       </div>`)}
     </div>
   </body>`;


### PR DESCRIPTION
Hello,

This is some ARIA markup to improve the Feather Wiki experience for [Screen Reader](https://en.wikipedia.org/wiki/Screen_reader) users. Almost all the elements are perfectly marked up.

The first commit allows screen readers to announce the notification text as they appear, e.g. when saving Feather Wiki back to a server.

I'd also like to add a *toolbar* role for the Pell action bar via a query selector, so that all the formatting buttons could be grouped and skipped, but I'm not sure where it would be best to do this.

Ideally, this would be great to have upstream, but given that the last commit for Pell (even for v2) was back in 2019, I am not sure how much attention it would receive among the 50+ other reported issues.

Any input is greatly appreciated.