### PR TITLE
Update slugifyTitle translation in Japanese

### DIFF
--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -94,7 +94,7 @@
   "showHtml": "HTML を表示",
   "showMenuButton": "メニューを表示",
   "slugExists": "スラッグ \"${page.slug}\" のページがすでに存在します！",
-  "slugifyTitle": "スラッグタイトル",
+  "slugifyTitle": "タイトルをスラッグへ",
   "status": "ステータス",
   "subheadingHelpText": "サブ見出し",
   "subPages": "サブページ",


### PR DESCRIPTION
The sentence was difficult to understand,
so I will improve this sentence.
- slugifyTitle: `スラッグタイトル` to `タイトルをスラッグへ`